### PR TITLE
add extendable fingerprinter with packet analysis, create generic/cowrie fingerprinter

### DIFF
--- a/prober/src/modules/__init__.py
+++ b/prober/src/modules/__init__.py
@@ -18,6 +18,7 @@ from .ssh_analyzer import (
     public_key_auth
 )
 from .prober import probe_ssh_server
+from .utils import clean_ansi_escape_codes
 
 __all__ = [
     'run_nmap_scan',
@@ -27,5 +28,6 @@ __all__ = [
     'try_ssh_auth',
     'password_auth',
     'public_key_auth',
-    'probe_ssh_server'
+    'probe_ssh_server',
+    'clean_ansi_escape_codes'
 ] 

--- a/prober/src/modules/auth_tester.py
+++ b/prober/src/modules/auth_tester.py
@@ -1,34 +1,44 @@
 """Module for testing SSH authentication"""
+from dataclasses import dataclass
+
 import paramiko
 from .credential_manager import CredentialManager
-from .honeypot_fingerprinter import HoneypotFingerprinter
+@dataclass
+class AuthTesterOutput:
+    banner: str
+    attempts: int
+    successes: int
+    success_patterns: dict
+
+    def get_success_rate(self):
+        if self.attempts == 0:
+            return 0.0
+        return self.successes / self.attempts
 
 class AuthTester:
     """Handles SSH authentication testing"""
     
     def __init__(self, credential_manager: CredentialManager):
         self.credential_manager = credential_manager
-        self.fingerprinter = HoneypotFingerprinter()
         self.banner = None
     
-    def test_auth(self, host: str, port: int, auth_func, num_attempts: int = 10) -> HoneypotFingerprinter:
+    def test_auth(self, host: str, port: int, auth_func, num_attempts: int = 10) -> AuthTesterOutput:
         """Perform multiple authentication attempts"""
         print(f"\n[*] Testing {num_attempts} authentication attempts on {host}:{port}")
-        
+        output = AuthTesterOutput(attempts=0, successes=0, success_patterns={}, banner="")
+
         for i in range(num_attempts):
             username, password = self.credential_manager.get_credential(i)
             transport = paramiko.Transport((host, port))
+            success = False
             try:
                 transport.start_client(timeout=5)
                 if i == 0:  # Only print banner on first attempt
-                    self.banner = transport.remote_version
-                    self.fingerprinter.set_banner(self.banner)
+                    output.banner = transport.remote_version
                     print(f"[+] SSH Banner: {self.banner}")
                 
                 auth_func(transport, username, password)
                 success = transport.is_authenticated()
-                self.fingerprinter.record_auth_attempt(success, username, password)
-                
                 if success:
                     print(f"[+] Auth succeeded for {username}@{host}")
                 else:
@@ -36,17 +46,23 @@ class AuthTester:
                     
             except Exception as e:
                 print(f"[!] Error during auth attempt {i+1}: {e}")
-                self.fingerprinter.record_auth_attempt(False, username, password)
+                success = False
             finally:
+                output.attempts += 1
+                if success:
+                    output.successes += 1
+                    if username and password:
+                        key = f"{username}:{password}"
+                        output.success_patterns[key] = True
                 transport.close()
-        
-        self._print_auth_analysis()
-        return self.fingerprinter
-    
-    def _print_auth_analysis(self):
+
+        self._print_auth_analysis(output)
+        return output
+
+    def _print_auth_analysis(self, output: AuthTesterOutput):
         """Print authentication analysis results"""
-        auth_rate = self.fingerprinter.get_auth_success_rate()
+        auth_rate = output.get_success_rate()
         print(f"\n[*] Authentication Analysis:")
         print(f"    Success Rate: {auth_rate:.2%}")
-        print(f"    Total Attempts: {self.fingerprinter.auth_attempts}")
-        print(f"    Successful Attempts: {self.fingerprinter.auth_successes}") 
+        print(f"    Total Attempts: {output.attempts}")
+        print(f"    Successful Attempts: {output.successes}")

--- a/prober/src/modules/fingerprints/__init__.py
+++ b/prober/src/modules/fingerprints/__init__.py
@@ -1,6 +1,7 @@
 from .cowrie_fingerprinter import CowrieFingerprinter
 from .generic_fingerprinter import GenericFingerprinter
 from .base_fingerprinter import BaseFingerprinter
+from .sshesame_fingerprinter import SSHSameFingerprinter
 
-__all__ = ['BaseFingerprinter', 'GenericFingerprinter', 'CowrieFingerprinter']
+__all__ = ['BaseFingerprinter', 'GenericFingerprinter', 'CowrieFingerprinter', 'SSHSameFingerprinter']
 

--- a/prober/src/modules/fingerprints/__init__.py
+++ b/prober/src/modules/fingerprints/__init__.py
@@ -1,0 +1,6 @@
+from .cowrie_fingerprinter import CowrieFingerprinter
+from .generic_fingerprinter import GenericFingerprinter
+from .base_fingerprinter import BaseFingerprinter
+
+__all__ = ['BaseFingerprinter', 'GenericFingerprinter', 'CowrieFingerprinter']
+

--- a/prober/src/modules/fingerprints/base_fingerprinter.py
+++ b/prober/src/modules/fingerprints/base_fingerprinter.py
@@ -1,0 +1,52 @@
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import List, Dict
+
+import pyshark
+
+from modules.auth_tester import AuthTesterOutput
+
+@dataclass
+class FingerprintRule:
+    name: str
+    id: str
+    evaluate: callable
+
+class BaseFingerprinter:
+    def __init__(self, results: Dict[str, str], rules: List[FingerprintRule],
+                 auth: AuthTesterOutput, pcap_file: str = None, use_pkt_analysis: bool = False) -> None:
+        self.results = results
+        self.auth = auth
+        self.rules = rules
+
+        self._rule_score = {}
+
+        self._pcap_obj = None
+        # load the packet file in memory only if any rule needs it.
+        if use_pkt_analysis:
+            self._pcap_obj = pyshark.FileCapture(pcap_file)
+
+    def get_score(self):
+        total_score = 0
+
+        for rule in self.rules:
+            try:
+                score = rule.evaluate()
+                total_score += score
+                self._rule_score[rule.id] = score
+            except Exception as e:
+                print(f"Rule {rule.name} failed. Maybe you didn't enable packet analyis for this fingerprinter?\n Error: {e}")
+
+        if self._pcap_obj is not None:
+            self._pcap_obj.close()
+        return total_score
+
+
+    def show_rules_overview(self):
+        print("==== Rules Overview === ")
+        for rule in self.rules:
+            print(f"{rule.name} - score: {self._rule_score[rule.id]}")
+
+    @abstractmethod
+    def compute_and_explain(self) -> bool | float:
+        pass

--- a/prober/src/modules/fingerprints/cowrie_fingerprinter.py
+++ b/prober/src/modules/fingerprints/cowrie_fingerprinter.py
@@ -1,0 +1,78 @@
+import re
+from typing import Dict
+from modules.auth_tester import AuthTesterOutput
+from .base_fingerprinter import BaseFingerprinter, FingerprintRule
+
+class CowrieFingerprinter(BaseFingerprinter):
+    def __init__(self, results: Dict[str, str], auth: AuthTesterOutput):
+        rules = [
+            FingerprintRule(
+                id="ping",
+                name="pinging google.com returns 29.89.32.244",
+                evaluate=self.parse_ping
+            ),
+            FingerprintRule(
+                id="ifconfig",
+                name="ifconfig loopback shows 110 packets, but different bytes.",
+                evaluate=self.parse_ifconfig
+            )
+        ]
+        super().__init__(
+            results=results,
+            rules=rules,
+            auth=auth
+        )
+
+    def compute_and_explain(self) -> bool | float:
+        score = super().get_score()
+        print("\n=== Cowrie Analysis ===")
+        print(f"Total Score: {score:.2f}")
+        self.show_rules_overview()
+
+        return score
+
+    def parse_ping(self) -> float:
+        """
+        For the ping command, Cowrie uses a deterministic way of generating links for a given hostname.
+        It computes an MD5 hash and computes the IP based on the first 8 hex characters.
+        Under this algorithm, google.com will resolve to 29.89.32.244.
+        More information: https://github.com/cowrie/cowrie/blob/a4e8372a3c95819e8bd075e2da77486e03b6d020/src/cowrie/commands/ping.py#L83
+        """
+        output = self.results["ping"]
+        if output == None:
+            return 0
+
+        match = re.search(r'\((\d{1,3}(?:\.\d{1,3}){3})\)', output)
+        if match:
+            ip = match.group(1)
+            if ip == "29.89.32.244": return 1
+        return 0
+
+    def parse_ifconfig(self) -> float:
+        """
+        When using ifconfig, Cowrie always shows loopback packets to be 110, but the number of bytes is different in two consecutive runs.
+        Source code: https://github.com/cowrie/cowrie/blob/a4e8372a3c95819e8bd075e2da77486e03b6d020/src/cowrie/commands/ifconfig.py#L59
+        """
+        output = self.results["ifconfig"]
+        if output == None:
+            return 0
+
+        interfaces = output.split('\n\n')
+        lo_blocks = [block for block in interfaces if block.strip().startswith('lo')]
+
+        rx_packets = []
+        rx_bytes = []
+
+        for block in lo_blocks:
+            match = re.search(r'RX packets:(\d+)', block)
+            if match:
+                rx_packets.append(int(match.group(1)))
+            match = re.search(r'RX bytes:(\d+)', block)
+            if match:
+                rx_bytes.append(int(match.group(1)))
+
+        if len(rx_packets) == 2 and len(rx_bytes) == 2:
+            if rx_packets[0] == rx_packets[1] == 110 and rx_bytes[0] != rx_bytes[1]:
+                return 0.8
+        return 0
+

--- a/prober/src/modules/fingerprints/generic_fingerprinter.py
+++ b/prober/src/modules/fingerprints/generic_fingerprinter.py
@@ -1,0 +1,125 @@
+from typing import Dict
+
+import re
+
+from modules.auth_tester import AuthTesterOutput
+from modules.fingerprints.base_fingerprinter import BaseFingerprinter, FingerprintRule
+from modules.utils import clean_ansi_escape_codes
+
+
+class GenericFingerprinter(BaseFingerprinter):
+    """"
+    Classifies a host as a honeypot or not, without focusing on a specific honeypot.
+    """
+
+    def __init__(self, results: Dict[str, str], auth: AuthTesterOutput, pcap_file: str):
+        rules = [
+            FingerprintRule(
+                id="empty_responses",
+                name="High empty/no response ratio",
+                evaluate = self.count_empty_responses
+            ),
+            FingerprintRule(
+                id="banner",
+                name="Old banner versions",
+                evaluate=self.analyze_banner
+            ),
+            FingerprintRule(
+                id="auth_patterns",
+                name="Suspicious auth patterns",
+                evaluate=self.analyze_auth_patterns
+            ),
+            FingerprintRule(
+                id="malformed_packets",
+                name="Only exchanged malformed SSH packets",
+                evaluate=self.check_malformed_packets,
+            )
+        ]
+        super().__init__(
+            results=results,
+            rules=rules,
+            auth=auth,
+            pcap_file=pcap_file,
+            use_pkt_analysis=True
+        )
+
+    def compute_and_explain(self) -> bool:
+        score = super().get_score()
+        is_honeypot = any([
+            score >= 2.5,  # Lower threshold but more comprehensive scoring
+            self._rule_score['empty_responses'] >= 0.5,  # 50% of commands gave empty/no response
+            self._rule_score['auth_patterns'] >= 0.8,  # Suspicious auth patterns
+            self._rule_score['banner'] >= 0.4  # Suspicious SSH banner
+        ])
+        print("\n=== Honeypot Analysis ===")
+        print(f"Total Score: {score:.2f}")
+        print(f"Is honeypot: {is_honeypot}")
+        super().show_rules_overview()
+
+        return is_honeypot
+
+
+    def count_empty_responses(self):
+        if self.results == None:
+            return 1
+
+        no_response_cnt = 0
+        for command, response in self.results.items():
+            # Count empty and no responses
+            if not response or not clean_ansi_escape_codes(response).strip():
+                no_response_cnt += 1
+
+        return no_response_cnt / len(self.results)
+
+    def analyze_banner(self):
+        """Analyze SSH banner for honeypot indicators"""
+        if not self.auth.banner:
+            return 0.0
+
+        # Common honeypot SSH banners and their scores
+        ssh_banners = {
+            r'SSH-2\.0-OpenSSH_6\.0p1 Debian-4\+deb7u\d+': 0.4,  # Old Debian version
+            r'SSH-2\.0-OpenSSH_5\.\d+': 0.5,  # Very old OpenSSH
+            r'SSH-2\.0-OpenSSH_[1-4]\.\d+': 0.8,  # Extremely old OpenSSH
+        }
+        score = 0.0
+        for pattern, weight in ssh_banners.items():
+            if re.search(pattern, self.auth.banner, re.IGNORECASE):
+                score += weight
+        return score
+
+    def analyze_auth_patterns(self):
+        """Analyze authentication patterns for suspicious behavior"""
+        score = 0.0
+
+        # Check if root login was allowed (suspicious)
+        root_logins = sum(1 for cred in self.auth.success_patterns if cred.startswith("root:"))
+        if root_logins > 0:
+            score += 0.5
+
+        # Check if same username worked with different passwords (very suspicious)
+        usernames = {}
+        for cred in self.auth.success_patterns:
+            username = cred.split(":")[0]
+            usernames[username] = usernames.get(username, 0) + 1
+            if usernames[username] > 1:
+                score += 0.8
+
+        return score
+
+    def check_malformed_packets(self):
+        """"Honeypots have only returned malformed SSH packets upon inspection."""
+        real_ssh_cnt = 0
+        for pkt in self._pcap_obj:
+            if hasattr(pkt, 'ssh'):
+                real_ssh_cnt += 1
+        try:
+            for pkt in self._pcap_obj:
+                if hasattr(pkt, 'ssh'):
+                    real_ssh_cnt += 1
+        except Exception as e:
+            print(f"Did you activate package analysis for this Packet parsing error: {e}")
+
+        if real_ssh_cnt == 0:
+            return 1.5
+        return 0

--- a/prober/src/modules/fingerprints/sshesame_fingerprinter.py
+++ b/prober/src/modules/fingerprints/sshesame_fingerprinter.py
@@ -1,0 +1,75 @@
+from typing import Dict
+from modules.auth_tester import AuthTesterOutput
+from .base_fingerprinter import BaseFingerprinter, FingerprintRule
+
+class SSHSameFingerprinter(BaseFingerprinter):
+    def __init__(self, results: Dict[str, str], auth: AuthTesterOutput):
+        rules = [
+            FingerprintRule(
+                id="auth_success_rate",
+                name="100% authentication success rate",
+                evaluate=self.check_auth_success_rate
+            ),
+            FingerprintRule(
+                id="empty_responses",
+                name="All commands return empty responses",
+                evaluate=self.check_empty_responses
+            ),
+            FingerprintRule(
+                id="command_logging",
+                name="Commands are logged but no output",
+                evaluate=self.check_command_logging
+            )
+        ]
+        super().__init__(
+            results=results,
+            rules=rules,
+            auth=auth
+        )
+
+    def compute_and_explain(self) -> bool:
+        score = super().get_score()
+        is_sshesame = score >= 2.5  # Need at least 2.5 points to be considered SSHSame
+        
+        print("\n=== SSHSame Analysis ===")
+        print(f"Total Score: {score:.2f}")
+        print(f"Is SSHSame: {is_sshesame}")
+        self.show_rules_overview()
+        
+        return is_sshesame
+
+    def check_auth_success_rate(self) -> float:
+        """Check if all authentication attempts succeeded"""
+        if self.auth.attempts == 0:
+            return 0.0
+        
+        success_rate = self.auth.get_success_rate()
+        if success_rate == 1.0:  # 100% success rate
+            return 1.0
+        return 0.0
+
+    def check_empty_responses(self) -> float:
+        """Check if all commands return empty responses"""
+        if not self.results:
+            return 0.0
+        
+        empty_count = 0
+        for command, response in self.results.items():
+            if not response or not response.strip():
+                empty_count += 1
+        
+        # If all responses are empty, return 1.0
+        if empty_count == len(self.results):
+            return 1.0
+        return 0.0
+
+    def check_command_logging(self) -> float:
+        """Check if commands are logged but no output is returned"""
+        if not self.results:
+            return 0.0
+        
+        # SSHSame logs commands but returns no output
+        # We can check if we have results for commands but they're all empty
+        if len(self.results) > 0 and all(not response or not response.strip() for response in self.results.values()):
+            return 1.0
+        return 0.0 

--- a/prober/src/modules/honeypot_fingerprinter.py
+++ b/prober/src/modules/honeypot_fingerprinter.py
@@ -2,199 +2,27 @@
 import re
 from typing import Dict
 
+from .auth_tester import AuthTesterOutput
+from .fingerprints.cowrie_fingerprinter import CowrieFingerprinter
+from .fingerprints.generic_fingerprinter import GenericFingerprinter
+
+
 class HoneypotFingerprinter:
     """Class to analyze SSH responses and determine if a system is likely a honeypot"""
     
-    def __init__(self):
-        # Define command patterns and their weights for honeypot detection
-        self.command_patterns = {
-            'whoami': {
-                'weight': 2.0,
-                'honeypot_indicators': [
-                    (r'root', 0.3),  # Most honeypots run as root
-                    (r'admin', 0.2),  # Common honeypot username
-                    (r'^root\s*$', 0.5),  # Exact match for just "root" (common in honeypots)
-                ],
-                'no_response_score': 0.8,  # High score for no response
-                'empty_response_score': 0.6  # Score for empty response
-            },
-            'ls': {
-                'weight': 1.5,
-                'honeypot_indicators': [
-                    (r'\.bash_history', 0.4),  # Empty or minimal bash history
-                    (r'\.ssh', 0.3),  # Empty or minimal SSH directory
-                    (r'\.bashrc', 0.2),  # Default bashrc
-                    (r'^$', 0.8),  # Completely empty response (very suspicious)
-                    (r'^\s*$', 0.7),  # Only whitespace response
-                ],
-                'no_response_score': 0.7,  # High score for no response
-                'empty_response_score': 0.8  # Score for empty response
-            },
-            'uname': {
-                'weight': 1.0,
-                'honeypot_indicators': [
-                    (r'Linux.*Debian', 0.3),  # Generic Debian response
-                    (r'x86_64', 0.1),  # Generic architecture
-                    (r'3\.2\.0-4-amd64', 0.4),  # Specific old kernel version (common in honeypots)
-                    (r'#1 SMP', 0.2),  # Generic kernel build
-                ],
-                'no_response_score': 0.6,  # Medium score for no response
-                'empty_response_score': 0.5  # Score for empty response
-            },
-            'ps': {
-                'weight': 2.0,
-                'honeypot_indicators': [
-                    (r'few processes', 0.5),  # Minimal process list
-                    (r'no processes', 0.4),  # No processes
-                    (r'^USER\s+PID.*\n\s*$', 0.9),  # Only header, no processes (very suspicious)
-                    (r'USER\s+PID.*START.*\n.*$', 0.4),  # Suspicious process format
-                ],
-                'no_response_score': 0.9,  # Very high score for no response
-                'empty_response_score': 0.8  # Score for empty response
-            }
-        }
-        
-        # Common honeypot SSH banners and their scores
-        self.ssh_banners = {
-            r'SSH-2\.0-OpenSSH_6\.0p1 Debian-4\+deb7u\d+': 0.4,  # Old Debian version
-            r'SSH-2\.0-OpenSSH_5\.\d+': 0.5,  # Very old OpenSSH
-            r'SSH-2\.0-OpenSSH_[1-4]\.\d+': 0.8,  # Extremely old OpenSSH
-        }
-        
-        # Track authentication attempts
-        self.auth_attempts = 0
-        self.auth_successes = 0
-        self.auth_success_pattern = {}  # Track which credentials worked
-        self.banner = None
-        
-    def set_banner(self, banner: str):
-        """Set the SSH banner for analysis"""
-        self.banner = banner
-        
-    def record_auth_attempt(self, success: bool, username: str = None, password: str = None):
-        """Record an authentication attempt with credentials"""
-        self.auth_attempts += 1
-        if success:
-            self.auth_successes += 1
-            if username and password:
-                key = f"{username}:{password}"
-                self.auth_success_pattern[key] = True
-    
-    def get_auth_success_rate(self) -> float:
-        """Calculate the authentication success rate"""
-        if self.auth_attempts == 0:
-            return 0.0
-        return self.auth_successes / self.auth_attempts
-    
-    def analyze_auth_patterns(self) -> float:
-        """Analyze authentication patterns for suspicious behavior"""
-        score = 0.0
-        
-        # Check if root login was allowed (suspicious)
-        root_logins = sum(1 for cred in self.auth_success_pattern if cred.startswith("root:"))
-        if root_logins > 0:
-            score += 0.5
-        
-        # Check if same username worked with different passwords (very suspicious)
-        usernames = {}
-        for cred in self.auth_success_pattern:
-            username = cred.split(":")[0]
-            usernames[username] = usernames.get(username, 0) + 1
-            if usernames[username] > 1:
-                score += 0.8
-        
-        return score
-        
-    def analyze_response(self, command: str, response: str) -> float:
-        """Analyze a single command response and return a honeypot probability score"""
-        if command not in self.command_patterns:
-            return 0.0
-            
-        pattern_info = self.command_patterns[command]
-        score = 0.0
-        
-        # Check for no response or empty response
-        if not response:
-            return pattern_info['no_response_score'] * pattern_info['weight']
-        
-        # Clean and check response
-        cleaned_response = clean_ansi_escape_codes(response).strip()
-        
-        # Empty response check
-        if not cleaned_response:
-            return pattern_info['empty_response_score'] * pattern_info['weight']
-        
-        # Check for minimal response
-        if len(cleaned_response) < 5:
-            return pattern_info['empty_response_score'] * pattern_info['weight'] * 0.8
-        
-        # Check for pattern matches
-        for pattern, weight in pattern_info['honeypot_indicators']:
-            if re.search(pattern, cleaned_response, re.IGNORECASE | re.MULTILINE):
-                score += weight
-                
-        return score * pattern_info['weight']
-    
-    def analyze_banner(self) -> float:
-        """Analyze SSH banner for honeypot indicators"""
-        if not self.banner:
-            return 0.0
-            
-        score = 0.0
-        for pattern, weight in self.ssh_banners.items():
-            if re.search(pattern, self.banner, re.IGNORECASE):
-                score += weight
-        return score
-    
-    def analyze_all_responses(self, results: Dict[str, str]) -> Dict[str, float]:
-        """Analyze all command responses and return detailed scores"""
-        analysis = {
-            'command_scores': {},
-            'total_score': 0.0,
-            'is_honeypot': False,
-            'no_response_count': 0,
-            'empty_response_count': 0,
-            'total_commands': len(results),
-            'auth_success_rate': self.get_auth_success_rate(),
-            'banner_score': self.analyze_banner(),
-            'auth_pattern_score': self.analyze_auth_patterns()
-        }
-        
-        for command, response in results.items():
-            score = self.analyze_response(command, response)
-            analysis['command_scores'][command] = score
-            analysis['total_score'] += score
-            
-            # Count empty and no responses
-            if not response:
-                analysis['no_response_count'] += 1
-            elif not clean_ansi_escape_codes(response).strip():
-                analysis['empty_response_count'] += 1
-        
-        # Add banner score
-        analysis['total_score'] += analysis['banner_score']
-        
-        # Add authentication pattern score
-        analysis['total_score'] += analysis['auth_pattern_score']
-        
-        # Calculate empty response ratio (including both no response and empty response)
-        analysis['empty_response_ratio'] = (
-            analysis['no_response_count'] + analysis['empty_response_count']
-        ) / analysis['total_commands']
-        
-        # Consider it a honeypot if any of these conditions are met:
-        analysis['is_honeypot'] = any([
-            analysis['total_score'] >= 2.5,  # Lower threshold but more comprehensive scoring
-            analysis['empty_response_ratio'] >= 0.5,  # 50% of commands gave empty/no response
-            analysis['auth_pattern_score'] >= 0.8,  # Suspicious auth patterns
-            analysis['banner_score'] >= 0.4  # Suspicious SSH banner
-        ])
-        
-        return analysis
+    def __init__(self, results: Dict[str, str], auth_output: AuthTesterOutput, pcap_file: str):
+        self.auth = auth_output
+        self.results = results
+        self.pcap_file = pcap_file
 
-def clean_ansi_escape_codes(text: str) -> str:
-    """Remove ANSI escape codes from text"""
-    if not text:
-        return ""
-    ansi_escape = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
-    return ansi_escape.sub('', text) 
+    def analyze_all_responses(self) -> Dict[str, bool | float]:
+        generic_fingerprinter = GenericFingerprinter(results=self.results, auth=self.auth, pcap_file=self.pcap_file)
+        honeypot_outcome = generic_fingerprinter.compute_and_explain()
+
+        cowrie_fingerprinter = CowrieFingerprinter(results=self.results, auth=self.auth)
+        cowrie_score = cowrie_fingerprinter.compute_and_explain()
+
+        return {
+            'is_honeypot': honeypot_outcome,
+            'cowrie_score': cowrie_score
+        }

--- a/prober/src/modules/honeypot_fingerprinter.py
+++ b/prober/src/modules/honeypot_fingerprinter.py
@@ -5,6 +5,7 @@ from typing import Dict
 from .auth_tester import AuthTesterOutput
 from .fingerprints.cowrie_fingerprinter import CowrieFingerprinter
 from .fingerprints.generic_fingerprinter import GenericFingerprinter
+from .fingerprints.sshesame_fingerprinter import SSHSameFingerprinter
 
 
 class HoneypotFingerprinter:
@@ -22,7 +23,11 @@ class HoneypotFingerprinter:
         cowrie_fingerprinter = CowrieFingerprinter(results=self.results, auth=self.auth)
         cowrie_score = cowrie_fingerprinter.compute_and_explain()
 
+        sshesame_fingerprinter = SSHSameFingerprinter(results=self.results, auth=self.auth)
+        sshesame_score = sshesame_fingerprinter.compute_and_explain()
+
         return {
             'is_honeypot': honeypot_outcome,
-            'cowrie_score': cowrie_score
+            'cowrie_score': cowrie_score,
+            'sshesame_score': sshesame_score
         }

--- a/prober/src/modules/prober.py
+++ b/prober/src/modules/prober.py
@@ -1,5 +1,6 @@
 import time
 from .capture import start_packet_capture, stop_packet_capture
+from .honeypot_fingerprinter import HoneypotFingerprinter
 from .ssh_analyzer import try_ssh_auth, password_auth, analyze_pcap
 
 def probe_ssh_server(host, port, username, password, pcap_file, interface,commands):
@@ -7,7 +8,17 @@ def probe_ssh_server(host, port, username, password, pcap_file, interface,comman
     print(f"Probing {host}:{port} with {username}@{password}")
     capture_proc = start_packet_capture(pcap_file, interface, port=port)
     time.sleep(5)
-    try_ssh_auth(host, port, username, password_auth, password,commands)
-    time.sleep(5)
+    cmd_results, auth_output = try_ssh_auth(host, port, username, password_auth, password,commands)
+    time.sleep(10)
+    print(cmd_results)
     stop_packet_capture(capture_proc)
-    analyze_pcap(pcap_file) 
+    fingerprinter = HoneypotFingerprinter(
+        results=cmd_results,
+        auth_output=auth_output,
+        pcap_file=pcap_file
+    )
+    time.sleep(5)
+    fingerprinter.analyze_all_responses()
+    time.sleep(5)
+    analyze_pcap(pcap_file)
+

--- a/prober/src/modules/utils.py
+++ b/prober/src/modules/utils.py
@@ -1,0 +1,7 @@
+import re
+def clean_ansi_escape_codes(text: str) -> str:
+    """Remove ANSI escape codes from text"""
+    if not text:
+        return ""
+    ansi_escape = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
+    return ansi_escape.sub('', text)

--- a/prober/src/probe.py
+++ b/prober/src/probe.py
@@ -17,7 +17,9 @@ def main():
         "whoami": "whoami",
         "ls": "ls -la",   
         "ps": "ps aux",
-        "uname": "uname -a"
+        "uname": "uname -a",
+        "ping": "ping -c 1 google.com",
+        "ifconfig": "ifconfig && ifconfig"
     }
     # 3. Probe each target
     interface = 'eth0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 paramiko>=3.0.0 
 python-nmap>=0.7.1
+pyshark


### PR DESCRIPTION
- decoupled AuthTester and HoneypotFingerprinter
- created a BaseFingerprinter that can be used to add rules to score any honeypot.
    - if specified, rules can be evaluated under a context which makes exchanged packets available.
- moved fingerprinting logic to a GenericFingerprinter, responsible for determining whether a host is a honeypot or not.
- added a CowrieFingerprinter which tests the output of Cowrie-specific commands.