### PR TITLE
add randomly generated credentials in auth tester

### DIFF
--- a/prober/src/modules/auth_tester.py
+++ b/prober/src/modules/auth_tester.py
@@ -15,21 +15,24 @@ class AuthTesterOutput:
             return 0.0
         return self.successes / self.attempts
 
+
 class AuthTester:
     """Handles SSH authentication testing"""
     
-    def __init__(self, credential_manager: CredentialManager):
+    def __init__(self, credential_manager: CredentialManager, host: str = None, port: int = 22, auth_func=None):
         self.credential_manager = credential_manager
-        self.banner = None
+        self.host = host
+        self.port = port
+        self.auth_func = auth_func
     
-    def test_auth(self, host: str, port: int, auth_func, num_attempts: int = 10) -> AuthTesterOutput:
+    def test_auth(self) -> AuthTesterOutput:
         """Perform multiple authentication attempts"""
-        print(f"\n[*] Testing {num_attempts} authentication attempts on {host}:{port}")
+        num_attempts = len(self.credential_manager.credentials)
+        print(f"\n[*] Testing {num_attempts} authentication attempts on {self.host}:{self.port}")
         output = AuthTesterOutput(attempts=0, successes=0, success_patterns={}, banner="")
 
-        for i in range(num_attempts):
-            username, password = self.credential_manager.get_credential(i)
-            transport = paramiko.Transport((host, port))
+        for i, (username, password) in enumerate(self.credential_manager.credentials):
+            transport = paramiko.Transport((self.host, self.port))
             success = False
             try:
                 transport.start_client(timeout=5)
@@ -37,12 +40,12 @@ class AuthTester:
                     output.banner = transport.remote_version
                     print(f"[+] SSH Banner: {output.banner}", flush=True)
                 
-                auth_func(transport, username, password)
+                self.auth_func(transport, username, password)
                 success = transport.is_authenticated()
                 if success:
-                    print(f"[+] Auth succeeded for {username}@{host}")
+                    print(f"[+] Auth succeeded for {username}@{self.host}")
                 else:
-                    print(f"[-] Auth failed for {username}@{host}")
+                    print(f"[-] Auth failed for {username}@{self.host}")
                     
             except Exception as e:
                 print(f"[!] Error during auth attempt {i+1}: {e}")

--- a/prober/src/modules/credential_manager.py
+++ b/prober/src/modules/credential_manager.py
@@ -1,4 +1,6 @@
 """Module for managing SSH credentials for testing"""
+import random
+import string
 
 class CredentialManager:
     """Manages SSH credentials for testing"""
@@ -6,7 +8,8 @@ class CredentialManager:
     def __init__(self):
         self.credentials = []
         self._load_default_credentials()
-    
+        self._gen_canary_credentials()
+
     def _load_default_credentials(self):
         """Load default set of credentials"""
         self.credentials = [
@@ -21,6 +24,15 @@ class CredentialManager:
             ("ubuntu", "ubuntu"),
             ("debian", "debian")
         ]
+
+    def _gen_canary_credentials(self, count: int = 5):
+        """
+        Generate a specified number of random credential pairs and adds them to the canary credentials list.
+        """
+        for _ in range(count):
+            username = ''.join(random.choices(string.ascii_lowercase, k=8))
+            password = ''.join(random.choices(string.ascii_letters + string.digits, k=10))
+            self.add_credential(username, password)
     
     def add_credential(self, username: str, password: str):
         """Add a new credential pair"""
@@ -29,11 +41,3 @@ class CredentialManager:
     def add_credentials(self, credentials: list):
         """Add multiple credential pairs"""
         self.credentials.extend(credentials)
-    
-    def get_credential(self, index: int) -> tuple:
-        """Get credential pair at specified index"""
-        return self.credentials[index % len(self.credentials)]
-    
-    def get_credential_count(self) -> int:
-        """Get total number of credentials"""
- 

--- a/prober/src/modules/fingerprints/generic_fingerprinter.py
+++ b/prober/src/modules/fingerprints/generic_fingerprinter.py
@@ -29,11 +29,6 @@ class GenericFingerprinter(BaseFingerprinter):
                 name="Suspicious auth patterns",
                 evaluate=self.analyze_auth_patterns
             ),
-            FingerprintRule(
-                id="malformed_packets",
-                name="Only exchanged malformed SSH packets",
-                evaluate=self.check_malformed_packets,
-            )
         ]
         super().__init__(
             results=results,
@@ -58,9 +53,8 @@ class GenericFingerprinter(BaseFingerprinter):
 
         return is_honeypot
 
-
     def count_empty_responses(self):
-        if self.results == None:
+        if self.results is None:
             return 1
 
         no_response_cnt = 0
@@ -106,20 +100,3 @@ class GenericFingerprinter(BaseFingerprinter):
                 score += 0.8
 
         return score
-
-    def check_malformed_packets(self):
-        """"Honeypots have only returned malformed SSH packets upon inspection."""
-        real_ssh_cnt = 0
-        for pkt in self._pcap_obj:
-            if hasattr(pkt, 'ssh'):
-                real_ssh_cnt += 1
-        try:
-            for pkt in self._pcap_obj:
-                if hasattr(pkt, 'ssh'):
-                    real_ssh_cnt += 1
-        except Exception as e:
-            print(f"Did you activate package analysis for this Packet parsing error: {e}")
-
-        if real_ssh_cnt == 0:
-            return 1.5
-        return 0

--- a/prober/src/modules/fingerprints/sshesame_fingerprinter.py
+++ b/prober/src/modules/fingerprints/sshesame_fingerprinter.py
@@ -10,16 +10,6 @@ class SSHSameFingerprinter(BaseFingerprinter):
                 name="100% authentication success rate",
                 evaluate=self.check_auth_success_rate
             ),
-            FingerprintRule(
-                id="empty_responses",
-                name="All commands return empty responses",
-                evaluate=self.check_empty_responses
-            ),
-            FingerprintRule(
-                id="command_logging",
-                name="Commands are logged but no output",
-                evaluate=self.check_command_logging
-            )
         ]
         super().__init__(
             results=results,
@@ -39,37 +29,15 @@ class SSHSameFingerprinter(BaseFingerprinter):
         return is_sshesame
 
     def check_auth_success_rate(self) -> float:
-        """Check if all authentication attempts succeeded"""
+        """
+        Check if all authentication attempts succeeded.
+        SSHesame has the default behavior of allowing all authentication attempts,
+         and we have added 5 canary credentials made of randomly generated usernames and passwords, which the honeypot will always accept.
+        """
         if self.auth.attempts == 0:
             return 0.0
         
         success_rate = self.auth.get_success_rate()
         if success_rate == 1.0:  # 100% success rate
-            return 1.0
+            return 2.5
         return 0.0
-
-    def check_empty_responses(self) -> float:
-        """Check if all commands return empty responses"""
-        if not self.results:
-            return 0.0
-        
-        empty_count = 0
-        for command, response in self.results.items():
-            if not response or not response.strip():
-                empty_count += 1
-        
-        # If all responses are empty, return 1.0
-        if empty_count == len(self.results):
-            return 1.0
-        return 0.0
-
-    def check_command_logging(self) -> float:
-        """Check if commands are logged but no output is returned"""
-        if not self.results:
-            return 0.0
-        
-        # SSHSame logs commands but returns no output
-        # We can check if we have results for commands but they're all empty
-        if len(self.results) > 0 and all(not response or not response.strip() for response in self.results.values()):
-            return 1.0
-        return 0.0 

--- a/prober/src/modules/ssh_analyzer.py
+++ b/prober/src/modules/ssh_analyzer.py
@@ -53,8 +53,13 @@ def wait_for_output(session, command):
 def try_multiple_auth(host: str, port: int, auth_func, auth_arg, num_attempts: int = 10) -> AuthTesterOutput:
     """Try multiple authentication attempts with different credentials"""
     credential_manager = CredentialManager()
-    auth_tester = AuthTester(credential_manager)
-    return auth_tester.test_auth(host, port, auth_func, num_attempts)
+    auth_tester = AuthTester(
+        credential_manager = credential_manager,
+        host=host,
+        port=port,
+        auth_func=auth_func
+    )
+    return auth_tester.test_auth()
 
 def try_ssh_auth(host: str, port: int, username: str, auth_func, auth_arg, commands: Dict[str, str]) -> Tuple[Optional[Dict[str, str]], Optional[AuthTesterOutput]]:
     """Try to authenticate to the SSH server and print the result"""


### PR DESCRIPTION
add pairs of "canary" credentials that are randomly-generated on each run to use in SSHesame detection.